### PR TITLE
api version variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ To migrate from the official OpenAI model to the Azure OpenAI model, you can jus
             endpoint: {your-azure-openai-resource-endpoint},
             // deploymentName is optional, if you donot set it, you need to set it in the request parameter
             deploymentName: {your-azure-openai-resource-deployment-name},
+            // deploymentName is optional, if you donot set it, `2023-03-15-preview` will be applied
+            apiVersion: {your-azure-openai-resource-api-version},
          }
       }),
    );

--- a/api.ts
+++ b/api.ts
@@ -1948,7 +1948,7 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             let localVarPath = `/chat/completions`;
             if (configuration.azure) {
                 let deploymentName = configuration.azure.deploymentName ? configuration.azure.deploymentName : createChatCompletionRequest.model;
-                let apiVersion = configuration.azure.apiVersion ? configuration.azure.deploymentName : "2023-03-15-preview";
+                let apiVersion = configuration.azure.apiVersion ? configuration.azure.apiVersion: "2023-03-15-preview";
                 localVarPath = `/openai/deployments/${deploymentName}/chat/completions?api-version=${apiVersion}`;
             }
 
@@ -2027,7 +2027,7 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             let localVarPath = `/completions`;
             if (configuration.azure) {
                 let deploymentName = configuration.azure.deploymentName ? configuration.azure.deploymentName : createCompletionRequest.model;
-                let apiVersion = configuration.azure.apiVersion ? configuration.azure.deploymentName : "2023-03-15-preview";
+                let apiVersion = configuration.azure.apiVersion ? configuration.azure.apiVersion : "2023-03-15-preview";
                 localVarPath = `/openai/deployments/${deploymentName}/completions?api-version=${apiVersion}`;
             }
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -2104,7 +2104,7 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             let localVarPath = `/embeddings`;
             if (configuration.azure) {
                 let deploymentName = configuration.azure.deploymentName ? configuration.azure.deploymentName : createEmbeddingRequest.model;
-                let apiVersion = configuration.azure.apiVersion ? configuration.azure.deploymentName : "2023-03-15-preview";
+                let apiVersion = configuration.azure.apiVersion ? configuration.azure.apiVersion : "2023-03-15-preview";
                 localVarPath = `/openai/deployments/${deploymentName}/embeddings?api-version=${apiVersion}`;
             }
             // use dummy base URL string because the URL constructor only accepts absolute URLs.

--- a/api.ts
+++ b/api.ts
@@ -1948,7 +1948,8 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             let localVarPath = `/chat/completions`;
             if (configuration.azure) {
                 let deploymentName = configuration.azure.deploymentName ? configuration.azure.deploymentName : createChatCompletionRequest.model;
-                localVarPath = `/openai/deployments/${deploymentName}/chat/completions?api-version=2023-03-15-preview`;
+                let apiVersion = configuration.azure.apiVersion ? configuration.azure.deploymentName : "2023-03-15-preview";
+                localVarPath = `/openai/deployments/${deploymentName}/chat/completions?api-version=${apiVersion}`;
             }
 
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -2026,7 +2027,8 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             let localVarPath = `/completions`;
             if (configuration.azure) {
                 let deploymentName = configuration.azure.deploymentName ? configuration.azure.deploymentName : createCompletionRequest.model;
-                localVarPath = `/openai/deployments/${deploymentName}/completions?api-version=2023-03-15-preview`;
+                let apiVersion = configuration.azure.apiVersion ? configuration.azure.deploymentName : "2023-03-15-preview";
+                localVarPath = `/openai/deployments/${deploymentName}/completions?api-version=${apiVersion}`;
             }
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -2102,7 +2104,8 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             let localVarPath = `/embeddings`;
             if (configuration.azure) {
                 let deploymentName = configuration.azure.deploymentName ? configuration.azure.deploymentName : createEmbeddingRequest.model;
-                localVarPath = `/openai/deployments/${deploymentName}/embeddings?api-version=2023-03-15-preview`;
+                let apiVersion = configuration.azure.apiVersion ? configuration.azure.deploymentName : "2023-03-15-preview";
+                localVarPath = `/openai/deployments/${deploymentName}/embeddings?api-version=${apiVersion}`;
             }
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);

--- a/configuration.ts
+++ b/configuration.ts
@@ -19,6 +19,7 @@ export interface AzureConfigurationParameters {
     apiKey?: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>);
     endpoint?: string;
     deploymentName?: string;
+    apiVersion?: string;
 }
 
 export interface ConfigurationParameters {

--- a/dist/api.js
+++ b/dist/api.js
@@ -127,7 +127,7 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
             let localVarPath = `/chat/completions`;
             if (configuration.azure) {
                 let deploymentName = configuration.azure.deploymentName ? configuration.azure.deploymentName : createChatCompletionRequest.model;
-                let apiVersion = configuration.azure.apiVersion ? configuration.azure.deploymentName : "2023-03-15-preview";
+                let apiVersion = configuration.azure.apiVersion ? configuration.azure.apiVersion : "2023-03-15-preview";
                 localVarPath = `/openai/deployments/${deploymentName}/chat/completions?api-version=${apiVersion}`;
             }
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -193,7 +193,7 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
             let localVarPath = `/completions`;
             if (configuration.azure) {
                 let deploymentName = configuration.azure.deploymentName ? configuration.azure.deploymentName : createCompletionRequest.model;
-                let apiVersion = configuration.azure.apiVersion ? configuration.azure.deploymentName : "2023-03-15-preview";
+                let apiVersion = configuration.azure.apiVersion ? configuration.azure.apiVersion : "2023-03-15-preview";
                 localVarPath = `/openai/deployments/${deploymentName}/completions?api-version=${apiVersion}`;
             }
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -258,7 +258,7 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
             let localVarPath = `/embeddings`;
             if (configuration.azure) {
                 let deploymentName = configuration.azure.deploymentName ? configuration.azure.deploymentName : createEmbeddingRequest.model;
-                let apiVersion = configuration.azure.apiVersion ? configuration.azure.deploymentName : "2023-03-15-preview";
+                let apiVersion = configuration.azure.apiVersion ? configuration.azure.apiVersion : "2023-03-15-preview";
                 localVarPath = `/openai/deployments/${deploymentName}/embeddings?api-version=${apiVersion}`;
             }
             // use dummy base URL string because the URL constructor only accepts absolute URLs.

--- a/dist/api.js
+++ b/dist/api.js
@@ -127,7 +127,8 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
             let localVarPath = `/chat/completions`;
             if (configuration.azure) {
                 let deploymentName = configuration.azure.deploymentName ? configuration.azure.deploymentName : createChatCompletionRequest.model;
-                localVarPath = `/openai/deployments/${deploymentName}/chat/completions?api-version=2023-03-15-preview`;
+                let apiVersion = configuration.azure.apiVersion ? configuration.azure.deploymentName : "2023-03-15-preview";
+                localVarPath = `/openai/deployments/${deploymentName}/chat/completions?api-version=${apiVersion}`;
             }
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, common_1.DUMMY_BASE_URL);
@@ -192,7 +193,8 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
             let localVarPath = `/completions`;
             if (configuration.azure) {
                 let deploymentName = configuration.azure.deploymentName ? configuration.azure.deploymentName : createCompletionRequest.model;
-                localVarPath = `/openai/deployments/${deploymentName}/completions?api-version=2023-03-15-preview`;
+                let apiVersion = configuration.azure.apiVersion ? configuration.azure.deploymentName : "2023-03-15-preview";
+                localVarPath = `/openai/deployments/${deploymentName}/completions?api-version=${apiVersion}`;
             }
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, common_1.DUMMY_BASE_URL);
@@ -256,7 +258,8 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
             let localVarPath = `/embeddings`;
             if (configuration.azure) {
                 let deploymentName = configuration.azure.deploymentName ? configuration.azure.deploymentName : createEmbeddingRequest.model;
-                localVarPath = `/openai/deployments/${deploymentName}/embeddings?api-version=2023-03-15-preview`;
+                let apiVersion = configuration.azure.apiVersion ? configuration.azure.deploymentName : "2023-03-15-preview";
+                localVarPath = `/openai/deployments/${deploymentName}/embeddings?api-version=${apiVersion}`;
             }
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, common_1.DUMMY_BASE_URL);

--- a/dist/configuration.d.ts
+++ b/dist/configuration.d.ts
@@ -13,6 +13,7 @@ export interface AzureConfigurationParameters {
     apiKey?: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>);
     endpoint?: string;
     deploymentName?: string;
+    apiVersion?: string;
 }
 export interface ConfigurationParameters {
     apiKey?: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>);


### PR DESCRIPTION
Hi. I am a beginner in programming.
I am using your wonderful package with my tools.
This package made the transition to Azure Open AI a smooth one.
However, the API version is fixed and cannot be flexibly adapted to API versions that are updated daily.

Therefore, we prepared a variable for API Version and edited the script to allow the user to set it arbitrarily.
The user can optionally set the version with the `apiVersion` variable, otherwise `2023-03-15-preview` is applied.
If there is no problem with my commit and you like it, can you merge it?